### PR TITLE
Chore: add `is-plain-object` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@types/semver": "^7.3.4",
 				"axios": "^0.21.1",
 				"dotenv": "^8.2.0",
+				"is-plain-object": "^5.0.0",
 				"json-parse": "^1.0.3",
 				"json-parse-even-better-errors": "^2.3.1",
 				"lodash": "^4.17.20",
@@ -2424,6 +2425,17 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/clone-deep/node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/clone-deep/node_modules/kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3406,6 +3418,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"is-plain-object": "^2.0.4"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend-shallow/node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -4438,13 +4462,9 @@
 			}
 		},
 		"node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5719,6 +5739,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/mixin-deep/node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/mkdirp": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -6943,6 +6975,18 @@
 				"is-extendable": "^0.1.1",
 				"is-plain-object": "^2.0.3",
 				"split-string": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/set-value/node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -10536,6 +10580,14 @@
 				"shallow-clone": "^3.0.0"
 			},
 			"dependencies": {
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
 				"kind-of": {
 					"version": "6.0.3",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -11246,6 +11298,15 @@
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
 				}
 			}
 		},
@@ -11954,12 +12015,9 @@
 			}
 		},
 		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"requires": {
-				"isobject": "^3.0.1"
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.0",
@@ -12901,6 +12959,15 @@
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
 				}
 			}
 		},
@@ -13763,6 +13830,17 @@
 				"is-extendable": "^0.1.1",
 				"is-plain-object": "^2.0.3",
 				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				}
 			}
 		},
 		"shallow-clone": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@types/semver": "^7.3.4",
 		"axios": "^0.21.1",
 		"dotenv": "^8.2.0",
+		"is-plain-object": "^5.0.0",
 		"json-parse": "^1.0.3",
 		"json-parse-even-better-errors": "^2.3.1",
 		"lodash": "^4.17.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,12 +2688,24 @@
   dependencies:
     "kind-of" "^3.0.2"
 
-"is-plain-object@^2.0.3", "is-plain-object@^2.0.4", "is-plain-object@^5.0.0":
+"is-plain-object@^2.0.3":
   "integrity" "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="
   "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
   "version" "2.0.4"
   dependencies:
     "isobject" "^3.0.1"
+
+"is-plain-object@^2.0.4":
+  "integrity" "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="
+  "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
+  "version" "2.0.4"
+  dependencies:
+    "isobject" "^3.0.1"
+
+"is-plain-object@^5.0.0":
+  "integrity" "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+  "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz"
+  "version" "5.0.0"
 
 "is-potential-custom-element-name@^1.0.0":
   "integrity" "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="


### PR DESCRIPTION
It seems that the recent [issue-commands](https://github.com/oam-dev/kubevela/actions/workflows/issue-commands.yml) workflow keeps failing.

This commit fixes this issue by adding `is-plain-object` as a dependency.

## TODO

- [ ] Release v0.4.2
- [ ] Update reference in workflow definition (https://github.com/oam-dev/kubevela/pull/3451)

---

I tested with my personal repository

- [Actions Log](https://github.com/devholic/actions-test/runs/5556139697?check_suite_focus=true)
- [Workflow](https://github.com/devholic/actions-test/blob/390e16ed67e4b3b5b525f04741b339b440d9202a/.github/workflows/issue.yaml)

Signed-off-by: Sunghoon Kang <hoon@linecorp.com>